### PR TITLE
Grab bag of updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,21 @@
+REGISTRY_URL ?= ghcr.io/kate-goldenring/performance
+
 k6-build:
 	go install go.k6.io/xk6/cmd/xk6@latest
 	xk6 build --with github.com/LeonAdato/xk6-output-statsd --with github.com/grafana/xk6-kubernetes
 
+build-k6-image:
+	cd image/k6 && \
+	docker build --platform linux/amd64,linux/arm64 -t $(REGISTRY_URL)/k6:latest .
+
+push-k6-image:
+	docker push $(REGISTRY_URL)/k6:latest
+
 build-and-push-apps:
-	./apps/build-and-push.sh
+	./apps/build-and-push.sh $(REGISTRY_URL)
+
+deploy-apps:
+	./apps/deploy.sh $(REGISTRY_URL)
+
+run-tests:
+	./tests/run.sh $(REGISTRY_URL)

--- a/README.md
+++ b/README.md
@@ -38,30 +38,39 @@ sed -i '' 's/0\.0\.0\.0/<NODE_IP>/g' $HOME/.kube/config
 
 ## Executing a Test with the k6 Operator
 
-1. [Install the operator](https://github.com/grafana/k6-operator/tree/main?tab=readme-ov-file#deployment-with-helm)
+1. Install _all the operators_ in the Kubernetes environment you're pointed at after [Setting Up Your Cluster](#setting-up-your-cluster)
 
-   ```sh
-   helm repo add grafana https://grafana.github.io/helm-charts
-    helm repo update
-    helm install k6-operator grafana/k6-operator
-    ```
-
-2. Create a ConfigMap with the script
+    Here we're pointed to a generic Kubernetes cluster and just need to run the [spin-kube-k8s.sh](./environment/spin-kube-k8s.sh) script:
 
     ```sh
-    kubectl create configmap hello-world-rust --from-file ./tests/hello-world/script.js
+    ./environment/spin-kube-k8s.sh
     ```
 
-3. Run the test by applying the `TestRun` resource
+1. (Optional) Build and push all of the test apps with your own `REGISTRY_URL`
 
     ```sh
-    kubectl apply -f tests/hello-world/test-run.yaml 
+    export REGISRY_URL=ghcr.io/kate-goldenring/performance
+    make build-and-push-apps
     ```
 
-4. Once the `hello-world-rust-1-*` Pod has `Completed` you can get the results of the test:
+1. Deploy the Spin Apps
 
     ```sh
-    kubectl logs hello-world-rust-1-*
+    make deploy-apps
+    ```
+
+1. Run the tests
+
+    ```sh
+    make run-tests
+    ```
+
+1. Once the test Pods have `Completed` you can get the results of the tests
+
+    Here we view the logs from the pod corresponding to the `hello-world-rust-1` job:
+
+    ```sh
+    kubectl logs -f job/hello-world-rust-1
     ```
     
     Output should look similar to:

--- a/apps/hello-world-py/.gitignore
+++ b/apps/hello-world-py/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 *.wasm
 .spin
+.venv

--- a/environment/spin-kube-k3d.sh
+++ b/environment/spin-kube-k3d.sh
@@ -32,6 +32,7 @@ fi
 k3d cluster create $CLUSTER_NAME ${cluster_args[@]}
 
 install_cert_manager
+install_k6_operator
 install_spin_operator
 
 # Generate kubeconfig at $HOME/.kube/config

--- a/environment/spin-kube-k3s.sh
+++ b/environment/spin-kube-k3s.sh
@@ -30,6 +30,7 @@ curl -sfL https://get.k3s.io | sh -s - server --write-kubeconfig-mode '0644' ${c
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
 install_cert_manager
+install_k6_operator
 install_kwasm_operator
 
 # Re-export kubeconfig as kwasm operator may restart the k3s process 

--- a/environment/spin-kube-k8s.sh
+++ b/environment/spin-kube-k8s.sh
@@ -8,5 +8,6 @@ for binary in kubectl helm; do
 done
 
 install_cert_manager
+install_k6_operator
 install_kwasm_operator
 install_spin_operator

--- a/tests/hello-world/test-run.yaml
+++ b/tests/hello-world/test-run.yaml
@@ -1,23 +1,22 @@
+# NOTE: this TestRun resource is intended to be dynamically updated prior to
+# running, eg via tests/run.sh
 apiVersion: k6.io/v1alpha1
 kind: TestRun
 metadata:
-  name: hello-world-rust
+  name: $name
 spec:
   parallelism: 1
   script:
     configMap:
-      name: hello-world-rust
+      name: $name
       file: script.js
   separate: false
   runner:
-    env:
-      - name: SERVICE
-        value: hello-world-rust
-      - name: ROUTE
-        value: "hello"
+    image: $runner_image
+    env: []
     metadata:
       labels:
-        language: rust
+        language: $language
     securityContext:
       runAsUser: 1000
       runAsGroup: 1000

--- a/utils.sh
+++ b/utils.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+# Function: which_binary
+# Description:
+# Finds and prints the path of the specified binary if it exists in the system's PATH.
+# If the binary is not found, it prints an error message.
+# Parameters:
+# $1 - The name of the binary to locate.
+which_binary() {
+  local binary_name="$1"
+  local binary_path
+  binary_path=$(command -v "$binary_name")
+  if [[ -n "$binary_path" ]]; then
+    echo "$binary_path"
+  else
+    echo "Could not find $binary_name" >&2
+    exit 1
+  fi
+}


### PR DESCRIPTION
Tried my best to break up chunks of updates into commits, so maybe helpful to look at them one-by-one.

Basically just updating things to:
- incorporate the k6-operator install into the environment scripts
- add deploy.sh script (and Make target) to deploy test apps to a cluster
- update run.sh to submit TestRuns to the operator
- templatize the hello-world/test-run.yaml file to enable iterating over all of the test apps in run.sh

This still doesn't yet bring in the Datadog chart, that will be next.  Also didn't test w/ a Prometheus endpoint...
 