### PR TITLE
feat(terraform): add initial azure/aks setup

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,5 @@
+*tfstate*
+.terraform/
+.terraform.lock.hcl
+terraform.tfvars
+*tfplan*

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -1,0 +1,92 @@
+# Based on https://github.com/jpflueger/spin-k8s-bench/blob/main/infra/azure/main.tf
+
+resource "random_id" "cluster_name" {
+  byte_length = 4
+}
+
+# Local for tag to attach to all items
+locals {
+  base_name = "${var.prefix}${random_id.cluster_name.hex}"
+  tags = merge(
+    var.tags,
+    {
+      "ClusterName" = local.base_name
+    },
+  )
+}
+
+resource "azurerm_resource_group" "rg" {
+  name     = "rg-${local.base_name}"
+  location = var.location
+}
+
+resource "azurerm_kubernetes_cluster" "aks" {
+  name = "aks-${local.base_name}"
+
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+
+  kubernetes_version = var.kubernetes_version
+  sku_tier           = var.sku_tier
+
+  azure_policy_enabled             = false
+  http_application_routing_enabled = false
+
+  dns_prefix = local.base_name
+  network_profile {
+    network_plugin    = "azure"
+    network_policy    = "azure"
+    load_balancer_sku = "standard"
+  }
+
+  default_node_pool {
+    name                         = var.system_nodepool.name
+    node_count                   = var.system_nodepool.min
+    vm_size                      = var.system_nodepool.size
+    enable_auto_scaling          = var.system_nodepool.min != var.system_nodepool.max
+    min_count                    = var.system_nodepool.min != var.system_nodepool.max ? var.system_nodepool.min : null
+    max_count                    = var.system_nodepool.min != var.system_nodepool.max ? var.system_nodepool.max : null
+    only_critical_addons_enabled = true
+    vnet_subnet_id               = azurerm_subnet.aks.id
+  }
+
+  # TODO: see monitoring.tf
+  #
+  # oms_agent {
+  #   log_analytics_workspace_id      = azurerm_log_analytics_workspace.main.id
+  #   msi_auth_for_monitoring_enabled = true
+  # }
+
+  # monitor_metrics {
+  #   annotations_allowed = length(var.metric_annotations_allowlist) > 0 ? join(",", var.metric_annotations_allowlist) : null
+  #   labels_allowed      = length(var.metric_labels_allowlist) > 0 ? join(",", var.metric_labels_allowlist) : null
+  # }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "user_nodepools" {
+  count = length(var.user_nodepools)
+
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.aks.id
+  name                  = var.user_nodepools[count.index].name
+  vm_size               = var.user_nodepools[count.index].size
+
+  mode    = "User"
+  os_type = "Linux"
+  os_sku  = "Ubuntu"
+
+  node_count  = var.user_nodepools[count.index].node_count
+  node_labels = var.user_nodepools[count.index].labels
+  node_taints = var.user_nodepools[count.index].taints
+
+  max_pods = var.user_nodepools[count.index].max_pods
+
+  vnet_subnet_id = azurerm_subnet.user_nodepools[count.index].id
+
+  tags = local.tags
+}

--- a/terraform/azure/monitoring.tf
+++ b/terraform/azure/monitoring.tf
@@ -1,0 +1,1 @@
+### TODO(maybe?): Bring in all or subset of https://github.com/jpflueger/spin-k8s-bench/blob/main/infra/azure/monitoring.tf

--- a/terraform/azure/outputs.tf
+++ b/terraform/azure/outputs.tf
@@ -1,0 +1,10 @@
+output "kube_config" {
+  value     = azurerm_kubernetes_cluster.aks.kube_config_raw
+  sensitive = true
+}
+
+# TODO: see monitoring.tf
+#
+# output "grafana_endpoint" {
+#   value = azurerm_dashboard_grafana.grafana.endpoint
+# }

--- a/terraform/azure/providers.tf
+++ b/terraform/azure/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">=1.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "3.99.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/terraform/azure/terraform.tfvars.tmpl
+++ b/terraform/azure/terraform.tfvars.tmpl
@@ -1,0 +1,31 @@
+prefix = "spinkubeperf"
+
+location = "westus2"
+
+system_nodepool = {
+  name = "agentpool"
+  size = "Standard_DS2_v2"
+  min  = 2
+  max  = 3
+}
+
+user_nodepools = [{
+  name       = "shim"
+  size       = "Standard_DS2_v2"
+  node_count = 2
+  max_pods   = 250
+  labels = {
+    "runtime" = "containerd-shim-spin"
+  }
+  taints = []
+}]
+
+tags = {
+  "Purpose" = "Testing SpinKube Performance"
+}
+
+# TODO: see monitoring.tf
+#
+# to set the current user as an admin you can get your user id from the az cli
+# example: az ad signed-in-user show -o tsv --query id
+# grafana_admins = [  ]

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -1,0 +1,80 @@
+variable "prefix" {
+  default = ""
+}
+
+variable "location" {
+  default = "westus2"
+  type    = string
+}
+
+variable "kubernetes_version" {
+  default = "1.29.2"
+  type    = string
+}
+
+variable "sku_tier" {
+  default = "Free"
+  type    = string
+}
+
+variable "system_nodepool" {
+  type = object({
+    name = string
+    size = string
+    min  = number
+    max  = number
+  })
+  default = {
+    name = "agentpool"
+    size = "Standard_DS2_v2"
+    min  = 2
+    max  = 3
+  }
+}
+
+variable "user_nodepools" {
+  type = list(object({
+    name       = string
+    size       = string
+    node_count = number
+    max_pods   = number
+    labels     = map(string)
+    taints     = list(string)
+  }))
+  default = [{
+    name       = "shim"
+    size       = "Standard_DS2_v2"
+    node_count = 1
+    max_pods   = 250
+    labels = {
+      "runtime" = "containerd-shim-spin"
+    }
+    taints = []
+  }]
+}
+
+variable "tags" {
+  description = "Map of extra tags to attach to items which accept them"
+  type        = map(string)
+  default     = {}
+}
+
+# TODO: see monitoring.tf
+#
+# variable "grafana_admins" {
+#   description = "List of object id's to be assigned as Grafana admins"
+#   type = list(string)
+#   default = []
+# }
+
+# variable "metric_annotations_allowlist" {
+#   description = "Specifies a list of Kubernetes annotation keys that will be used in the resource's labels metric."
+#   type        = list(string)
+#   default     = []
+# }
+
+# variable "metric_labels_allowlist" {
+#   description = "(Optional) Specifies a Comma-separated list of additional Kubernetes label keys that will be used in the resource's labels metric."
+#   type        = list(string)
+#   default     = []
+# }

--- a/terraform/azure/vnet.tf
+++ b/terraform/azure/vnet.tf
@@ -1,0 +1,27 @@
+# Based on https://github.com/jpflueger/spin-k8s-bench/blob/main/infra/azure/vnet.tf
+
+resource "azurerm_virtual_network" "main" {
+  name = "vnet-${local.base_name}"
+
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+
+  address_space = ["10.10.0.0/16"]
+}
+
+resource "azurerm_subnet" "aks" {
+  name                 = "default"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefixes     = ["10.10.1.0/24"]
+}
+
+resource "azurerm_subnet" "user_nodepools" {
+  count = length(var.user_nodepools)
+
+  name                 = var.user_nodepools[count.index].name
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.main.name
+
+  address_prefixes = ["10.10.${count.index + 2}.0/23"]
+}


### PR DESCRIPTION
- Add initial terraform/azure setup, borrowed heavily from https://github.com/jpflueger/spin-k8s-bench
  - put a TODO on the monitoring resources since we're intending to send to Datadog, but I know @kate-goldenring mentioned wanting to check out the managed Grafana offering
  - cut out ACI stuff

cc @jpflueger for any pointers/advice/etc.