### PR TITLE
misc(*): version fix; README update

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -6,7 +6,7 @@ on:
 
 env:
   REGISTRY_URL: ghcr.io/${{github.repository}}
-  SPIN_V_VERSION: v2.4.2
+  SPIN_V_VERSION: "2.4.2"
   # Terraform env vars associated with configuration variables
   TF_VAR_prefix: ci-spinkube-perf
 

--- a/.github/workflows/build-and-push-spinapps.yaml
+++ b/.github/workflows/build-and-push-spinapps.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
     REGISTRY_URL: ghcr.io/${{github.repository}}
-    SPIN_V_VERSION: v2.4.2
+    SPIN_V_VERSION: "2.4.2"
     
 jobs:
   apps:
@@ -21,7 +21,7 @@ jobs:
       - name: Install Spin
         uses: fermyon/actions/spin/setup@v1
         with:
-          version: ${{ env.SPIN_V_VERSION }}
+          version: "v${{ env.SPIN_V_VERSION }}"
 
       - name: Install TinyGo
         uses: acifani/setup-tinygo@v2

--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ sed -i '' 's/0\.0\.0\.0/<NODE_IP>/g' $HOME/.kube/config
     ./environment/spin-kube-k8s.sh
     ```
 
-1. (Optional) Build and push all of the test apps with your own `REGISTRY_URL`
+1. (Optional) If using your own `REGISTRY_URL`, you'll want to build and push the apps as well as the k6 operator image:
 
     ```sh
     export REGISRY_URL=ghcr.io/kate-goldenring/performance
     make build-and-push-apps
+    make build-k6-image push-k6-image
     ```
 
 1. Run the tests

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -32,7 +32,7 @@ wait_for_testrun() {
 REGISTRY_URL=${1:-"ghcr.io/kate-goldenring/performance"}
 TEST=${TEST:-"hello-world"}
 OUTPUT=${OUTPUT:-"datadog"}
-SPIN_V_VERSION=${SPIN_V_VERSION:-"v2.4.2"}
+SPIN_V_VERSION=${SPIN_V_VERSION:-"2.4.2"}
 # Navigate to the directory containing the script
 path="$(dirname "$0")/$TEST"
 echo "path is $path"


### PR DESCRIPTION
- fix: align spin version to be v-less (CI tests were looking for `v2.4.2` tag whereas the apps were pushed with a `2.4.2` tag)
- add mention of build/push k6 image in readme