### PR TITLE
Separate density test into distinct test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,20 @@ push-k6-image:
 build-and-push-apps:
 	./apps/build-and-push.sh $(REGISTRY_URL)
 
-run-tests:
+run-density-test-%:
+	SPIN_APP_REGISTRY_URL="rg.fr-par.scw.cloud/dlancshire-public/template-app-" TEST=density NAME=density-$* ./tests/run.sh $(REGISTRY_URL)
+	echo "Logs from Density Test $*"
+	kubectl logs job/density-$*-1
+
+run-density-tests: run-density-test-1 run-density-test-2 run-density-test-3
+	kubectl delete spinapp --all
+
+run-hello-world-test:
 	TEST=hello-world ./tests/run.sh $(REGISTRY_URL)
-	SPIN_APP_REGISTRY_URL="rg.fr-par.scw.cloud/dlancshire-public/template-app-" TEST=density ./tests/run.sh $(REGISTRY_URL)
+	echo "Logs from Hello World Test"
+	kubectl logs job/hello-world-1
+
+run-tests: run-hello-world-test run-density-tests
 
 cleanup: cleanup-apps cleanup-tests
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -57,7 +57,7 @@ export tag=$SPIN_V_VERSION
 export executor=${EXECUTOR:-"containerd-shim-spin"}
 export runner_image=$REGISTRY_URL/k6:latest
 export test_id=$TEST_ID
-export name=$TEST
+export name=${NAME:-$TEST}
 echo "Running test $name"
 
 # Create a tar archive of the test script and helper functions via the k6 runner image


### PR DESCRIPTION
This is much cleaner and lets us modify in workflows how many iterations of density tests to run (say if you provision bigger or smaller clusters)