### PR TITLE
Remove redundant executor declaration for constant-vus test

### DIFF
--- a/tests/scripts/constant-vus.js
+++ b/tests/scripts/constant-vus.js
@@ -25,7 +25,7 @@ export let options = {
   setupTimeout: '300s',
   noConnectionReuse: false,
   discardResponseBodies: true,
-  executor: 'constant-vus',
+  // executor: 'constant-vus', // this is the default executor and implied
   vus: 20,
   duration: testDuration,
 };


### PR DESCRIPTION
Default is constant-vus: https://k6.io/docs/using-k6/scenarios/executors/constant-vus/

closes #49