### PR TITLE
ci(aks): add dashboard url to workflow summary

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -76,7 +76,9 @@ jobs:
           export TEST_END_UTC=$(date '+%s%3N')
           export VARIABLE_KEYS=node_instance_type,node_os,node_arch,host,test_id
           export VARIABLE_VALS=$NODE_INSTANCE_TYPE,$NODE_OS,$NODE_ARCH,$NODE_HOST,$TEST_ID
-          ./dashboard/datadog-dashboard-url.sh
+          . ./dashboard/datadog-dashboard-url.sh
+          echo '### Datadog Dashboard URL:' >> $GITHUB_STEP_SUMMARY
+          echo "${DATADOG_DASHBOARD_URL}" >> $GITHUB_STEP_SUMMARY
 
       - name: Deprovision K8s cluster (AKS)
         if: ${{ always() }}

--- a/dashboard/datadog-dashboard-url.sh
+++ b/dashboard/datadog-dashboard-url.sh
@@ -51,3 +51,4 @@ url="${url}&view=spans&from_ts=$TEST_START_UTC&to_ts=$TEST_END_UTC&live=$live"
 
 echo "URL is:"
 echo $url
+export DATADOG_DASHBOARD_URL="${url}"


### PR DESCRIPTION
With this, the dashboard URL will be shown on the summary page for a given workflow.   Saves a few seconds for the user as they no longer need to crack open the job that echos it originally.