### PR TITLE
Update default skew to Standard_D2s_v5

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -7,7 +7,7 @@ on:
       apps_nodepool_sku:
         type: string
         description: "SKU for the node(s) running SpinApps"
-        default: 'Standard_A2_v2'
+        default: 'Standard_D2s_v5'
       datadog_dashboard_id:
         type: string
         description: 'ID of datadog dashboard'


### PR DESCRIPTION
Enables a more direct comparison to the arm Standard_D2ps_v5 skew
arm: Standard_D2ps_v5 https://learn.microsoft.com/en-us/azure/virtual-machines/dpsv5-dpdsv5-series
amd: standard_d2s_v5 https://learn.microsoft.com/en-us/azure/virtual-machines/dv5-dsv5-series