### PR TITLE
Update AKS instance skew of system node pool to Standard_D2s_v5

### DIFF
--- a/terraform/azure/aks/terraform.tfvars.tmpl
+++ b/terraform/azure/aks/terraform.tfvars.tmpl
@@ -4,14 +4,14 @@ location = "westus2"
 
 system_nodepool = {
   name = "agentpool"
-  size = "Standard_A2_v2"
+  size = "Standard_D2s_v5"
   min  = 1
   max  = 1
 }
 
 user_nodepools = [{
   name       = "apps"
-  size       = "Standard_A2_v2"
+  size       = "Standard_D2s_v5"
   node_count = 1
   max_pods   = 250
   labels = {
@@ -21,7 +21,7 @@ user_nodepools = [{
 },
 {
   name       = "system"
-  size       = "Standard_A2_v2"
+  size       = "Standard_D2s_v5"
   node_count = 1
   max_pods   = 100
   labels = {

--- a/terraform/azure/aks/variables.tf
+++ b/terraform/azure/aks/variables.tf
@@ -26,7 +26,7 @@ variable "system_nodepool" {
   })
   default = {
     name = "agentpool"
-    size = "Standard_A2_v2"
+    size = "Standard_D2s_v5"
     min  = 1
     max  = 1
   }
@@ -43,7 +43,7 @@ variable "user_nodepools" {
   }))
   default = [{
     name       = "apps"
-    size       = "Standard_A2_v2"
+    size       = "Standard_D2s_v5"
     node_count = 1
     max_pods   = 250
     labels = {
@@ -53,7 +53,7 @@ variable "user_nodepools" {
     },
     {
       name       = "system"
-      size       = "Standard_A2_v2"
+      size       = "Standard_D2s_v5"
       node_count = 1
       max_pods   = 100
       labels = {


### PR DESCRIPTION
We should avoid our system node pools being throttled too and support better network bandwidth than the [current skew](https://learn.microsoft.com/en-us/azure/virtual-machines/av2-series). Price increases from ~$50-~$70 a month.